### PR TITLE
Refactor/embedding service cleanup

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,9 +17,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: 'pip'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -50,9 +50,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: 'pip'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -66,7 +66,6 @@ jobs:
         else
           echo "No tests directory found - skipping tests"
         fi
-      continue-on-error: true
 
   frontend-lint:
     name: Frontend Linting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ We welcome code contributions including:
 4. **Generate test embeddings** (optional, for testing)
    ```bash
    # Add some test images to data/raw
-   python -m src.models.clip.generate_embeddings
+   python -m src.models.generate_embeddings
    ```
 
 5. **Start the backend server**

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pip install -r requirements.txt
 2. Generate embeddings for your collection:
 
 ```bash
-python -m src.models.clip.generate_embeddings
+python -m src.models.generate_embeddings
 ```
 
 This will process all images found in `raw_data_dir` and create embeddings in `embeddings_dir` (both set in `config.json`).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We present Digital Collections Explorer, a web-based, open-source exploratory se
 
 ### Prerequisites
 
-- Python 3.8+
+- Python 3.10+
 - Node.js 14+
 - Git
 - Docker (optional, for containerized deployment)

--- a/config.json
+++ b/config.json
@@ -5,10 +5,10 @@
   "embeddings_dir": "data/embeddings",
   "thumbnails_dir": "data/thumbnails",
   "model_config": {
-    "model_type": "siglip",
-    "model_name": "google/siglip-base-patch16-256-multilingual",
+    "model_type": "clip",
+    "model_name": "openai/clip-vit-base-patch32",
     "batch_size": 32,
-    "device": "mps"
+    "device": "cuda"
   },
   "api_config": {
     "host": "0.0.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+line_length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core dependencies
 torch>=2.0.0
 torchvision>=0.15.0
-transformers>=5.0.0
+transformers>=4.42.0
 sentencepiece>=0.1.99
 protobuf>=3.20.0
 open_clip_torch>=2.20.0

--- a/src/backend/api/routes/search.py
+++ b/src/backend/api/routes/search.py
@@ -6,8 +6,9 @@ from PIL import Image
 
 from ...models.schemas import SearchResponse, SearchResult
 from ...services.embedding_service import embedding_service
-from ...services.embedding_service_factory import \
-    embedding_service as model_service
+from ...services.embedding_service_factory import create_embedding_service
+
+model_service = create_embedding_service()
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/search", tags=["search"])
@@ -27,9 +28,11 @@ async def search_by_text(
             embedding_service.load_embeddings()
 
         text_embedding = model_service.encode_text(query)
-        logit_scale = model_service.model.logit_scale.exp().item()
         raw_results = embedding_service.search(
-            text_embedding, logit_scale=logit_scale, limit=limit, offset=offset
+            text_embedding,
+            score_transform=model_service.transform_score,
+            limit=limit,
+            offset=offset,
         )
 
         search_results = [
@@ -58,7 +61,10 @@ async def search_by_image(
         image = Image.open(BytesIO(image_data)).convert("RGB")
         image_embedding = model_service.encode_image(image)
         raw_results = embedding_service.search(
-            image_embedding, limit=limit, offset=offset
+            image_embedding,
+            score_transform=model_service.transform_score,
+            limit=limit,
+            offset=offset,
         )
 
         search_results = [

--- a/src/backend/services/__init__.py
+++ b/src/backend/services/__init__.py
@@ -1,14 +1,14 @@
 from .base_embedding_service import BaseEmbeddingService
 from .clip_service import CLIPService
-from .embedding_service_factory import (SIGLIP_AVAILABLE,
-                                        create_embedding_service,
-                                        embedding_service)
+from .embedding_service_factory import (
+    SIGLIP_AVAILABLE,
+    create_embedding_service,
+)
 
 __all__ = [
     "BaseEmbeddingService",
     "CLIPService",
     "create_embedding_service",
-    "embedding_service",
     "SIGLIP_AVAILABLE",
 ]
 

--- a/src/backend/services/base_embedding_service.py
+++ b/src/backend/services/base_embedding_service.py
@@ -77,3 +77,8 @@ class BaseEmbeddingService(ABC):
     def get_model_type(self) -> str:
         """Return the model type identifier (e.g., 'clip', 'siglip')"""
         pass
+
+    @abstractmethod
+    def transform_score(self, similarities: torch.Tensor) -> torch.Tensor:
+        """Apply model-specific scoring to raw cosine similarities."""
+        pass

--- a/src/backend/services/clip_service.py
+++ b/src/backend/services/clip_service.py
@@ -50,3 +50,7 @@ class CLIPService(BaseEmbeddingService):
             embeddings = extract_embeddings(image_features)
             embeddings = embeddings / embeddings.norm(dim=-1, keepdim=True)
         return embeddings.cpu()
+
+    def transform_score(self, similarities: torch.Tensor) -> torch.Tensor:
+        logit_scale = self.model.logit_scale.exp().item()
+        return similarities * logit_scale

--- a/src/backend/services/embedding_service.py
+++ b/src/backend/services/embedding_service.py
@@ -2,7 +2,7 @@ import json
 import logging
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import torch
 
@@ -102,19 +102,20 @@ class EmbeddingService:
     def search(
         self,
         query_embedding: torch.Tensor,
-        logit_scale: Optional[float] = None,
+        score_transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         limit: int = 20,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
-        """Search for similar items using query embedding with pagination"""
+        """Search by query embedding; optional score_transform on raw similarities."""
         try:
-            similarities = torch.matmul(self.embeddings, query_embedding.t()).squeeze()
+            scores = torch.matmul(
+                self.embeddings, query_embedding.t()
+            ).squeeze()
+            if score_transform is not None:
+                scores = score_transform(scores)
 
-            if logit_scale is not None:
-                similarities = similarities * logit_scale
-
-            top_k = min(offset + limit, len(similarities))
-            top_scores, top_indices = torch.topk(similarities, k=top_k)
+            top_k = min(offset + limit, len(scores))
+            top_scores, top_indices = torch.topk(scores, k=top_k)
 
             start_idx = min(offset, len(top_indices))
             end_idx = min(offset + limit, len(top_indices))

--- a/src/backend/services/embedding_service.py
+++ b/src/backend/services/embedding_service.py
@@ -108,9 +108,7 @@ class EmbeddingService:
     ) -> List[Dict[str, Any]]:
         """Search by query embedding; optional score_transform on raw similarities."""
         try:
-            scores = torch.matmul(
-                self.embeddings, query_embedding.t()
-            ).squeeze()
+            scores = torch.matmul(self.embeddings, query_embedding.t()).squeeze()
             if score_transform is not None:
                 scores = score_transform(scores)
 

--- a/src/backend/services/embedding_service_factory.py
+++ b/src/backend/services/embedding_service_factory.py
@@ -18,7 +18,7 @@ except ImportError:
     logger = logging.getLogger(__name__)
     logger.warning(
         "SigLIP support not available. "
-        "Install transformers>=5.0.0 to use SigLIP models: "
+        "Install transformers>=4.42.0 to use SigLIP models: "
         "pip install --upgrade transformers"
     )
 
@@ -36,8 +36,7 @@ def create_embedding_service() -> BaseEmbeddingService:
         ValueError: If model_type is not supported
     """
 
-    # Set default model type to clip if not set in config for backwards compatibility
-    model_type = settings.model_type.lower() or "clip"
+    model_type = settings.model_type.lower()
     model_name = settings.model_name
     device = settings.device
 
@@ -48,8 +47,8 @@ def create_embedding_service() -> BaseEmbeddingService:
     elif model_type == "siglip":
         if not SIGLIP_AVAILABLE:
             raise ImportError(
-                "SigLIP support requires transformers>=5.0.0. "
-                "Please upgrade: pip install --upgrade 'transformers>=5.0.0'"
+                "SigLIP support requires transformers>=4.42.0. "
+                "Please upgrade: pip install --upgrade 'transformers>=4.42.0'"
             )
         return SiglipService(model_name=model_name, device=device)
     else:
@@ -60,7 +59,3 @@ def create_embedding_service() -> BaseEmbeddingService:
             f"Unsupported model_type: {model_type}. "
             f"Supported types: {', '.join(repr(t) for t in supported_types)}"
         )
-
-
-# Create the singleton instance
-embedding_service = create_embedding_service()

--- a/src/backend/services/siglip_service.py
+++ b/src/backend/services/siglip_service.py
@@ -52,3 +52,8 @@ class SiglipService(BaseEmbeddingService):
             embeddings = extract_embeddings(image_features)
             embeddings = embeddings / embeddings.norm(dim=-1, keepdim=True)
         return embeddings.cpu()
+
+    def transform_score(self, similarities: torch.Tensor) -> torch.Tensor:
+        logit_scale = self.model.logit_scale.exp().item()
+        logit_bias = self.model.logit_bias.item()
+        return torch.sigmoid(logit_scale * similarities + logit_bias)

--- a/src/models/generate_embeddings.py
+++ b/src/models/generate_embeddings.py
@@ -13,9 +13,8 @@ from pdf2image import convert_from_path
 from PIL import Image
 
 from src.backend.core.config import settings
-from src.backend.services.embedding_service_factory import \
-    create_embedding_service
-from src.backend.utils.helpers import extract_embeddings
+from src.backend.services.base_embedding_service import BaseEmbeddingService
+from src.backend.services.embedding_service_factory import create_embedding_service
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -34,20 +33,14 @@ class ProcessingResult:
 
 
 def generate_embeddings(
-    model, processor, images, device="cuda", timing_info: Dict[str, float] = None
+    service: BaseEmbeddingService,
+    images,
+    timing_info: Dict[str, float] = None,
 ):
     """Generate embeddings for a list of images"""
     start_time = time.time()
     try:
-        inputs = processor(images=images, return_tensors="pt", padding=True)
-        inputs = {k: v.to(device) for k, v in inputs.items()}
-
-        with torch.no_grad():
-            image_features = model.get_image_features(**inputs)
-            embeddings = extract_embeddings(image_features)
-            embeddings = embeddings / embeddings.norm(dim=-1, keepdim=True)
-
-        return embeddings.cpu()
+        return service.encode_image(images)
     except Exception as e:
         logger.error(f"Error generating embeddings: {e}")
         return None
@@ -60,9 +53,7 @@ def generate_embeddings(
 def process_pdf(
     file_path,
     raw_data_dir,
-    model,
-    processor,
-    device,
+    service: BaseEmbeddingService,
     processed_dir,
     thumbnails_dir,
     timing_info: Dict[str, float],
@@ -113,9 +104,7 @@ def process_pdf(
                 processed_image_path = pdf_processed_dir / f"{i}.jpg"
                 processed_image.save(processed_image_path, "JPEG", quality=90)
 
-                page_embedding = generate_embeddings(
-                    model, processor, [image], device, timing_info
-                )
+                page_embedding = generate_embeddings(service, [image], timing_info)
                 if page_embedding is not None:
                     embeddings_list.append(
                         page_embedding[0]
@@ -162,9 +151,7 @@ def process_pdf(
 def process_image(
     file_path,
     raw_data_dir,
-    model,
-    processor,
-    device,
+    service: BaseEmbeddingService,
     processed_dir,
     thumbnails_dir,
     timing_info: Dict[str, float],
@@ -187,7 +174,7 @@ def process_image(
         processed_image_path = image_processed_dir / "0.jpg"
         processed_image.save(processed_image_path, "JPEG", quality=90)
 
-        embedding = generate_embeddings(model, processor, [image], device, timing_info)
+        embedding = generate_embeddings(service, [image], timing_info)
         if embedding is None:
             return None
 
@@ -215,9 +202,7 @@ def process_image(
 
 
 def process_files(
-    model: Any,
-    processor: Any,
-    device: str,
+    service: BaseEmbeddingService,
     raw_data_dir: Path,
     processed_dir: Path,
     thumbnails_dir: Path,
@@ -265,9 +250,7 @@ def process_files(
                 results = process_pdf(
                     file_path,
                     raw_data_dir,
-                    model,
-                    processor,
-                    device,
+                    service,
                     processed_dir,
                     thumbnails_dir,
                     timing_info,
@@ -276,9 +259,7 @@ def process_files(
                 results = process_image(
                     file_path,
                     raw_data_dir,
-                    model,
-                    processor,
-                    device,
+                    service,
                     processed_dir,
                     thumbnails_dir,
                     timing_info,
@@ -316,23 +297,16 @@ def main():
     PROCESSED_DIR.mkdir(parents=True, exist_ok=True)
     THUMBNAILS_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Create embedding service using factory
-    embedding_model_service = create_embedding_service()
+    service = create_embedding_service()
     logger.info(
-        f"Using {embedding_model_service.get_model_type().upper()} model: {embedding_model_service.model_name}"
+        f"Using {service.get_model_type().upper()} model: {service.model_name}"
     )
-    logger.info(f"Using device: {embedding_model_service.device}")
-
-    model = embedding_model_service.model
-    processor = embedding_model_service.processor
-    DEVICE = embedding_model_service.device
+    logger.info(f"Using device: {service.device}")
 
     embedding_timing_info = {"total_duration": 0.0}
 
     result = process_files(
-        model,
-        processor,
-        DEVICE,
+        service,
         RAW_DATA_DIR,
         PROCESSED_DIR,
         THUMBNAILS_DIR,

--- a/src/models/generate_embeddings.py
+++ b/src/models/generate_embeddings.py
@@ -298,9 +298,7 @@ def main():
     THUMBNAILS_DIR.mkdir(parents=True, exist_ok=True)
 
     service = create_embedding_service()
-    logger.info(
-        f"Using {service.get_model_type().upper()} model: {service.model_name}"
-    )
+    logger.info(f"Using {service.get_model_type().upper()} model: {service.model_name}")
     logger.info(f"Using device: {service.device}")
 
     embedding_timing_info = {"total_duration": 0.0}

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -226,10 +226,10 @@ class TestSearch:
         assert all("score" in r for r in results)
         assert all("metadata" in r for r in results)
 
-    def test_search_with_logit_scale(
+    def test_search_with_score_transform(
         self, embedding_service, mock_embeddings, mock_item_ids, mock_metadata
     ):
-        """Test search with logit scale parameter"""
+        """Test search with a score_transform callable applied to raw similarities"""
         embedding_service.is_loaded = True
         embedding_service.embeddings = mock_embeddings
         embedding_service.item_ids = mock_item_ids
@@ -237,9 +237,15 @@ class TestSearch:
 
         query_embedding = torch.randn(512, 1)
 
-        results = embedding_service.search(query_embedding, logit_scale=2.5, limit=5)
+        baseline = embedding_service.search(query_embedding, limit=5)
+        scaled = embedding_service.search(
+            query_embedding, score_transform=lambda s: s * 2.5, limit=5
+        )
 
-        assert len(results) <= 5
+        assert len(scaled) <= 5
+        assert [r["id"] for r in scaled] == [r["id"] for r in baseline]
+        for b, s in zip(baseline, scaled):
+            assert s["score"] == pytest.approx(b["score"] * 2.5, rel=1e-5)
 
     def test_search_with_pagination(
         self, embedding_service, mock_embeddings, mock_item_ids, mock_metadata

--- a/tests/test_embedding_service_factory.py
+++ b/tests/test_embedding_service_factory.py
@@ -7,8 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.backend.services.clip_service import CLIPService
-from src.backend.services.embedding_service_factory import \
-    create_embedding_service
+from src.backend.services.embedding_service_factory import create_embedding_service
 from src.backend.services.siglip_service import SiglipService
 
 


### PR DESCRIPTION
## Description

Make the offline embedding script use the new `BaseEmbeddingService` (it was bypassing it), stop the factory
from loading a model at import time, and fix SigLIP's scoring formula.

## Motivation and Context

1. **Abstraction not used in the offline path.** `generate_embeddings.py` reached into `service.model` / `.processor` directly, so adding a new model would require touching the batch script. Now it calls `service.encode_image()`.

2. **Module-level singleton** in `embedding_service_factory`. Importing the module triggered model download and collided with the existing vector-store `embedding_service` singleton.

3. **SigLIP scoring** used CLIP's formula (`logit_scale * sim`) instead of SigLIP's (`sigmoid(logit_scale * sim + logit_bias)`).

4. **`transformers>=5.0.0`** forced CLIP-only users to upgrade. SigLIP needs only `>=4.42.0`.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Research contribution (new models, evaluation methods, etc.)
- [x] Other (dependency cleanup):

## Component(s) Affected

<!-- Mark all that apply -->

- [x] Backend (Python/FastAPI)
- [ ] Frontend - Photographs
- [ ] Frontend - Maps
- [ ] Frontend - Documents
- [x] CLIP/ML models
- [x] Configuration
- [x] Documentation
- [x] Tests
- [x] Build/deployment

## Changes Made

<!-- List the main changes in bullet points -->

- Use `BaseEmbeddingService.encode_image()` in offline pipeline; drop `src/models/clip/` layer
- Remove module-level singleton from factory; `search.py` owns its instance
- Add `transform_score` abstract method; SigLIP applies `sigmoid(logit_scale * sim + logit_bias)`
- `EmbeddingService.search()` takes optional `score_transform` callable instead of scalar `logit_scale`
- Stop re-exporting `embedding_service` from `services/__init__.py` (avoids name collision)
- `transformers>=4.42.0`; restore `config.json` default to `clip` + `cuda`
- Add `pyproject.toml` with black + isort config
- Remove dead `or "clip"` fallback in factory
- Update `test_search_with_logit_scale` → `test_search_with_score_transform` to match new callable API
- Bump CI to Python 3.12 and remove `continue-on-error` from the pytest job (was masking failures)

## Testing

### How Has This Been Tested?

<!-- Describe the tests you ran and how to reproduce them -->

- [x] `pytest tests/` passes
- [x] Manual: text and image search via FastAPI on both CLIP and SigLIP

### Test Configuration

- **Collection type tested**: photographs
- **Python version**: 3.12
- **Node version**: 22
- **OS**: macOS
- **CLIP model**: openai/clip-vit-base-patch32
- **SigLIP model**: google/siglip-base-patch16-224

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate UI changes -->

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `black .` and `isort .` on Python code
- [ ] I have run `npm run lint` on frontend code (if applicable)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this locally with actual data

### Documentation

- [x] I have updated the documentation accordingly
- [x] I have updated the README if needed
- [x] I have added docstrings to new functions/classes
- [x] I have updated `config.json` documentation if config changes were made

### Dependencies

- [x] I have updated `requirements.txt` (if Python dependencies changed)
- [ ] I have updated `package.json` (if Node dependencies changed)
- [x] I have documented any new configuration options

### Research (if applicable)

- [ ] I have included references to relevant papers or research
- [ ] I have shared evaluation results or benchmarks
- [ ] I have included information about datasets used
- [ ] I have documented model training procedures

## Breaking Changes

Two internal-API changes; both updated in this PR:

- **`EmbeddingService.search()`**: parameter `logit_scale: Optional[float]` replaced with `score_transform: Optional[Callable[[Tensor], Tensor]]`.
- **`services/__init__.py`**: no longer re-exports `embedding_service` (it pointed to the factory's encoder, conflicting with the vector-store singleton). Import from `embedding_service_factory` directly.

## Additional Notes

<!-- Any additional information that reviewers should know -->

The `transform_score` abstraction makes explicit that absolute scores differ across models. Benchmarking should rely on rank-based metrics rather than score thresholds.

## Reviewers Checklist (for maintainers)

- [ ] Code quality and style compliance
- [ ] Test coverage adequate
- [ ] Documentation complete
- [ ] No security concerns
- [ ] Performance implications acceptable
- [ ] Breaking changes documented
